### PR TITLE
Fixed typo in `Configuration` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install # or yarn install
 
 ## Configuration
 ```
-cp config.js.example config.json
+cp config.json.example config.json
 # Edit the info inside config.json
 ```
 


### PR DESCRIPTION
Changed from `config.js.example` to `config.json.example`

Signed-off-by: Cocoa <0xbbc@0xbbc.com>