### PR TITLE
Added a feature that can attach most recent partial logs when sending diagnostic message

### DIFF
--- a/Core/Bot/diagnosticlog.js
+++ b/Core/Bot/diagnosticlog.js
@@ -1,19 +1,29 @@
+// Dependencies
+
+const fs = require("fs")
+const path = require("path")
+
 // Local Files
 
-let Telegram = require('./telegram')
-let config = require('../../config.json')
+const Telegram = require('./telegram')
+const config = require('../../config.json')
+const Store = require('../storage')
+const Log = require('../log').Log
+const LogFiles = require('../log').LogFiles
 
 let DiagnosticLog = {
     info: (text) => {
         DiagnosticLog.counter(text)
         if (config.diagnosticChannel.enable) {
             Telegram.Bot.telegram.sendMessage(`${config.diagnosticChannel.channel}`, "📄 Info\n" + text)
+            DiagnosticLog.attachLog()
         }
     },
     debug: (text) => {
         DiagnosticLog.counter(text)
         if (config.diagnosticChannel.enable && DiagnosticLog.count == 0) {
             Telegram.Bot.telegram.sendMessage(`${config.diagnosticChannel.channel}`, "⚙️ Debug\n" + text)
+            DiagnosticLog.attachLog()
         }
         Log.debug(text)
     },
@@ -21,6 +31,7 @@ let DiagnosticLog = {
         DiagnosticLog.counter(text)
         if (config.diagnosticChannel.enable && DiagnosticLog.count == 0) {
             Telegram.Bot.telegram.sendMessage(`${config.diagnosticChannel.channel}`, "⚠️ Warning\n" + text)
+            DiagnosticLog.attachLog()
         }
         Log.warning(text)
     },
@@ -39,6 +50,7 @@ let DiagnosticLog = {
                 stack = JSON.stringify(text.stack).replace(trimmer, ".")
             }
             Telegram.Bot.telegram.sendMessage(`@${config.diagnosticChannel.channel}`, "🚨 Fatal\n" + JSON.parse(stack))
+            DiagnosticLog.attachLog()
         }
         Log.fatal(text)
     },
@@ -55,7 +67,112 @@ let DiagnosticLog = {
             Store.insert({ "logtext": text.message ? text.message : "", key: "logtext" })
         })
     },
-    count: 0
+    count: 0,
+    attachLog: async () => {
+        if (config.diagnosticChannel.enable && config.diagnosticChannel.attachLog.enable) {
+            let numberOfLines = parseInt(config.diagnosticChannel.attachLog.line)
+            if (!isNaN(numberOfLines)) {
+                for (let logFile of LogFiles) {
+                    let snapshot = await DiagnosticLog.snapshotLogFile(logFile).catch(err => {
+                        console.error(err.stack)
+                    })
+                    let lines = await DiagnosticLog.readLines(snapshot, numberOfLines).catch(err => {
+                        console.error(err.stack)
+                    })
+                    if (lines.length == 0) return
+                    let partialSnapshotFile = DiagnosticLog.generateSnapshotFilename(logFile, "partial")
+                    let fd = fs.openSync(partialSnapshotFile, 'w')
+                    if (fd == undefined) console.error(`Partial log cannot be sent because cannot create file ${partialSnapshotFile}`)
+                    for (let line of lines) {
+                        fs.writeSync(fd, line)
+                        fs.writeSync(fd, "\n")
+                    }
+                    fs.close(fd)
+                    Telegram.Bot.telegram.sendDocument(`@${config.diagnosticChannel.channel}`, {
+                        source: fs.readFileSync(partialSnapshotFile),
+                        filename: path.basename(partialSnapshotFile)
+                    })
+                }
+            }
+        }
+    },
+    readLines: (file, num) => {
+        return new Promise((resolve, reject) => {
+            try {
+                let fd = fs.openSync(file, 'r')
+                let stat = fs.statSync(file)
+
+                let fileSize = stat.size
+                let lines = new Array()
+                
+                if (fileSize === 0) {
+                    resolve(lines)
+                } else {
+                    let bufferSize = 1024
+                    let currentPosition = fileSize - bufferSize
+                    if (currentPosition < 0) {
+                        currentPosition = 0
+                        bufferSize = fileSize
+                    }
+                    let buffer = new Buffer.alloc(bufferSize)
+                    let currentNumberOfLine = num
+                    
+                    while (true) {
+                        fs.readSync(fd, buffer, 0, bufferSize, currentPosition)
+                        
+                        let lineEnd = bufferSize
+                        
+                        let bytesLeft = buffer.length
+                        
+                        for (let i = buffer.length - 1; i >= 0 && currentNumberOfLine != 1; i--) {
+                            if (buffer[i] == 0x0A) {
+                                let line = buffer.slice(i + 1, lineEnd)
+                                lines.push(line.toString())
+                                lineEnd = i
+                                currentNumberOfLine--
+                                bytesLeft = i
+                            }
+                        }
+                        if (currentNumberOfLine != 1) {
+                            if (currentPosition >= bufferSize) {
+                                currentPosition = currentPosition - bufferSize + bytesLeft
+                            } else {
+                                if (currentPosition == 0) break
+                                
+                                bufferSize = bufferSize - currentPosition
+                                currentPosition = 0
+                            }
+                        } else {
+                            break
+                        }
+                    }
+                    
+                    resolve(lines.reverse())
+                }
+            }    
+            catch (err) {
+                reject(err)
+            }
+        })
+    },
+    generateSnapshotFilename: (file, midfix = "", snapshotDir = "cache/logs") => {
+        return path.join(snapshotDir, `${new Date().getTime()}-${midfix.length === 0 ? "" : midfix + "-"}` + path.basename(file))
+    },
+    snapshotLogFile: (file, midfix = "", snapshotDir = "cache/logs") => {
+        return new Promise((resolve, reject) => {
+            try {
+                if (!fs.existsSync(snapshotDir)) {
+                    fs.mkdirSync(snapshotDir, {recursive: true})
+                }
+                let snapshotFile = DiagnosticLog.generateSnapshotFilename(file, midfix, snapshotDir)
+                fs.copyFileSync(file, snapshotFile)
+                resolve(snapshotFile)
+            }
+            catch (err) {
+                reject(err)
+            }
+        })
+    }
 }
 
 module.exports = DiagnosticLog

--- a/Core/log.js
+++ b/Core/log.js
@@ -111,3 +111,4 @@ let AnonymousLog = {
 exports.AnonymousLog = AnonymousLog
 exports.msgLog = messageStdout
 exports.Log = Log
+exports.LogFiles = [coreLogFileName, messageLogFileName]

--- a/config.json.example
+++ b/config.json.example
@@ -16,7 +16,11 @@
     },
     "diagnosticChannel": {
         "enable": false,
-        "channel": "Channel Username or Channel ID"
+        "channel": "Channel Username or Channel ID",
+        "attachLog": {
+            "enable": false,
+            "line": 100
+        }
     },
     "database": {
         "base": "data/yawarakai.db",


### PR DESCRIPTION
Added a feature that can attach most recent partial logs when sending diagnostic message

Corresponding setting in `config.json`,

```json
    "diagnosticChannel": {
        "enable": false,
        "channel": "Channel Username or Channel ID",
        "attachLog": {
            "enable": false,
            "line": 100
        }
    },
```

